### PR TITLE
Add missing 'WHERE 1' and fix column name when getting schemas

### DIFF
--- a/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1553,9 +1553,9 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 //          + " WHERE nspname <> 'pg_toast' AND (nspname !~ '^pg_temp_' "
 //          + " OR nspname = (pg_catalog.current_schemas(true))[1]) AND (nspname !~ '^pg_toast_temp_' "
 //          + " OR nspname = replace((pg_catalog.current_schemas(true))[1], 'pg_temp_', 'pg_toast_temp_')) ";
-    sql = "SELECT name AS TABLE_SCHEM, '' AS TABLE_CATALOG FROM sys.sys_schemas";
+    sql = "SELECT name AS TABLE_SCHEM, '' AS TABLE_CATALOG FROM sys.sys_schemas WHERE 1";
     if (schemaPattern != null && !schemaPattern.isEmpty()) {
-      sql += " AND nspname LIKE " + escapeQuotes(schemaPattern);
+      sql += " AND name LIKE " + escapeQuotes(schemaPattern);
     }
     sql += " ORDER BY TABLE_SCHEM";
 


### PR DESCRIPTION
```
SELECT name AS TABLE_SCHEM, '' AS TABLE_CATALOG FROM sys.sys_schemas AND nspname LIKE ...
```
Syntax error with `AND`. And `nspname` does not exist in `sys.sys_schemas`.

```
SELECT name AS TABLE_SCHEM, '' AS TABLE_CATALOG FROM sys.sys_schemas WHERE 1 AND name LIKE ...
```